### PR TITLE
Add 'Customizing NetNewsWire' page to v6.1

### DIFF
--- a/pages/mac/6.1/en/customizing.markdown
+++ b/pages/mac/6.1/en/customizing.markdown
@@ -1,0 +1,15 @@
+@title Customizing NetNewsWire
+@template nnw5mac_en.html
+
+<!-- more topics to be added as more personalization and customization options become available -->
+
+Hide the unread badge in Dock
+-----------------------------
+
+NetNewsWire shows a red badge on its icon whenever you’ve got unread items. If you usually read all your new items (or mark them as read!), the badge lets you know that new articles have arrived. Exciting!
+
+However, if you leave unread items between visits to NetNewsWire, the badge can become distracting, less meaningful, or even stressful. You may find that turning it off is helpful.
+
+Open **System Preferences** → **Notifications** → **NetNewsWire** and unselect **Badge application icon**.
+
+Nonetheless, we advocate liberal use of *Mark as Read*. You don’t have to read everything!

--- a/pages/mac/6.1/en/index.markdown
+++ b/pages/mac/6.1/en/index.markdown
@@ -37,6 +37,7 @@ Get more help
 
 [Get more help with NetNewsWire](get-more-help)
 
+[Customizing NetNewsWire](customizing) – Dock icon badge
 
 Learn about the NetNewsWire project
 -----------------------------------


### PR DESCRIPTION
This PR adds a 'Customizing NetNewsWire' page with instructions to hide the badge from the dock icon.  Most of the words I copy-pasted from the v5.0 version of this page, except for the 1-liner that now accurately instructs the reader to go to System Preferences.  

It also adds a link to the new 'Customizing' page to the main TOC (I added it to the end of the "Get more help" section).

Earlier today I was trying to hide the badge icon.  I did a web search and clicked one of the top results, which unwittingly turned out to be the `/customizing` page from the v5.0 help site.  It said to use a checkbox in the application's preferences (which had since been removed in v6.0b3).  It was enough to confuse me for a bit.  Maybe this page will eventually get indexed above the old v5.0 version and help the next person!

If you want any changes or if I can do anything else, let me know.